### PR TITLE
Export timestamps relative to system clock

### DIFF
--- a/kepler/timer.py
+++ b/kepler/timer.py
@@ -1,9 +1,10 @@
 from __future__ import annotations
 
+from dataclasses import dataclass
 import collections
 import contextlib
 import contextvars
-from time import perf_counter_ns as current_time
+from time import perf_counter_ns as current_time, time_ns
 import typing
 from typing import Callable, Generator, Iterable, Mapping, Optional
 
@@ -16,6 +17,24 @@ from .event import CallerID, Log, ScopedEvents, TimingEvent
 
 
 GeneratorContextManager = contextlib._GeneratorContextManager  # type: ignore
+
+# Always use `current_time` to get a timestamp.
+# - This is the single source of truth for timestamps
+# - This time is not guaranteed to map to the system time!
+
+
+@dataclass
+class ExportContext:
+    perf_counter_ns_offset: int
+
+    def __init__(self):
+        self.perf_counter_ns_offset = time_ns() - current_time()
+
+    def convert(self, event: TimingEvent) -> TimingEvent:
+        return TimingEvent(
+            timestamp=event.timestamp + self.perf_counter_ns_offset,
+            duration=event.duration,
+        )
 
 
 class Timer:
@@ -46,9 +65,10 @@ class Timer:
                 yield value
                 current_iter = self.log(current_iter)
 
-    def export(self) -> Iterable[ScopedEvents]:
-        yield ScopedEvents(call_stack=(), events=self.events)
-        yield from self.context.export()
+    def export(self, ctx: ExportContext | None = None) -> Iterable[ScopedEvents]:
+        ctx = ctx or ExportContext()
+        yield ScopedEvents(call_stack=(), events=[ctx.convert(e) for e in self.events])
+        yield from self.context.export(ctx)
 
 
 class TimerContext:
@@ -79,9 +99,10 @@ class TimerContext:
 
         return split
 
-    def export(self) -> Iterable[ScopedEvents]:
+    def export(self, ctx: ExportContext | None = None) -> Iterable[ScopedEvents]:
+        ctx = ctx or ExportContext()
         for caller_id, timer in self.timers.items():
-            for events in timer.export():
+            for events in timer.export(ctx):
                 yield events.nest_under(caller_id)
         for caller_id, sw_ctx in self.stopwatches.items():
             sw_caller_id = CallerID(
@@ -89,7 +110,7 @@ class TimerContext:
                 caller_id.filename,
                 caller_id.lineno,
             )
-            for events in sw_ctx.export():
+            for events in sw_ctx.export(ctx):
                 yield events.nest_under(sw_caller_id)
 
 

--- a/tests/test_json_logs.py
+++ b/tests/test_json_logs.py
@@ -1,5 +1,6 @@
 from contextlib import ExitStack
 from dataclasses import dataclass
+from datetime import datetime, timedelta
 import json
 from pathlib import Path
 import pytest
@@ -552,3 +553,18 @@ def test_stopwatch_splits_with_conditional_context(context: timer.TimerContext):
             ((":stopwatch: watch", "outside_context"), 2),
         ]
     )
+
+
+def test_log_timestamps_use_system_time(context: timer.TimerContext):
+    """Test log timestamps use system time"""
+
+    with context:
+        with kepler.time("test"):
+            pass
+
+    log = captured_log(context)
+    now = datetime.now()
+    for scoped_events in log.events:
+        for event in scoped_events.events:
+            ts = datetime.fromtimestamp(event.timestamp / 1e9)
+            assert ts - now < timedelta(seconds=1)


### PR DESCRIPTION
`time.perf_counter_ns` uses the monotonic clock which isn't aligned with the system time.

- Keep using `perf_counter_ns` at runtime to keep the same performance
- At export time update the timestamps to align with the system time